### PR TITLE
Add plugin to build additional device SDK jar with dependencies

### DIFF
--- a/aws-iot-device-sdk-java/pom.xml
+++ b/aws-iot-device-sdk-java/pom.xml
@@ -101,6 +101,22 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>with-deps</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This is useful for building a jar to sit on a target platform rather than using it as part of a code project.

The same plugin could be used to build an additional samples jar with dependencies but I don't think how the samples jar is currently structured makes it beneficial as mvn is required to run them anyway.