### PR TITLE
add EndpointPattern for AWS IoT in China

### DIFF
--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/util/AwsIotWebSocketUrlSigner.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/util/AwsIotWebSocketUrlSigner.java
@@ -60,7 +60,7 @@ public class AwsIotWebSocketUrlSigner {
     /** URI for WebSocket endpoint when doing initial HTTP operation. */
     private static final String CANONICAL_URI = "/mqtt";
     /** endpoint pattern used for validation and extracting region. */
-    private static final Pattern EndpointPattern = Pattern.compile("iot\\.([\\w-]+)\\.amazonaws\\.com(\\:\\d+)?$");
+    private static final Pattern EndpointPattern = Pattern.compile("iot\\.([\\w-]+)\\.amazonaws\\.com(\\.cn\\:\\d+|\\:\\d+)?$");
     /** service name used for signing. */
     private static final String ServiceName = "iotdata";
 


### PR DESCRIPTION
current AwsIotWebSocketUrlSigner
throws follow Exception when use "awsAccessKeyId" and "awsSecretAccessKey" to access AWS IoT in China
`java.lang.IllegalArgumentException: Could not extract region from endpoint provided
	at com.amazonaws.services.iot.client.util.AwsIotWebSocketUrlSigner.<init>(AwsIotWebSocketUrlSigner.java:87)
	at com.amazonaws.services.iot.client.core.AwsIotWebsocketConnection.<init>(AwsIotWebsocketConnection.java:46)
	at com.amazonaws.services.iot.client.core.AbstractAwsIotClient.<init>(AbstractAwsIotClient.java:74)
	at com.amazonaws.services.iot.client.AWSIotMqttClient.<init>(AWSIotMqttClient.java:156)`

