### PR TITLE
Adds a constructor to provide a custom socketFactory.

### DIFF
--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/AWSIotMqttClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/AWSIotMqttClient.java
@@ -15,9 +15,10 @@
 
 package com.amazonaws.services.iot.client;
 
-import java.security.KeyStore;
-
 import com.amazonaws.services.iot.client.core.AbstractAwsIotClient;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.security.KeyStore;
 
 /**
  * This class is the main interface of the AWS IoT Java library. It provides
@@ -128,6 +129,30 @@ public class AWSIotMqttClient extends AbstractAwsIotClient {
      */
     public AWSIotMqttClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword) {
         super(clientEndpoint, clientId, keyStore, keyPassword);
+    }
+
+    /**
+     * Instantiates a new client using TLS 1.2 mutual authentication. Client
+     * certificate and private key should be used to initialize the KeyManager
+     * of the socketFactory.
+     *
+     * @param clientEndpoint
+     *            the client endpoint in the form of {@code <account-specific
+     *            prefix>.iot.<aws-region>.amazonaws.com}. The account-specific
+     *            prefix can be found on the AWS IoT console or by using the
+     *            {@code describe-endpoint} command through the AWS command line
+     *            interface.
+     * @param clientId
+     *            the client ID uniquely identify a MQTT connection. Two clients
+     *            with the same client ID are not allowed to be connected
+     *            concurrently to a same endpoint.
+     * @param socketFactory
+     *            A socketFactory instantiated with a Keystore containing the client X.509
+     *            certificate and private key, and a Truststore containing trusted
+     *            Certificate Authorities(CAs).
+     */
+    public AWSIotMqttClient(String clientEndpoint, String clientId, SSLSocketFactory socketFactory) {
+        super(clientEndpoint, clientId, socketFactory);
     }
 
     /**

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
@@ -33,6 +33,7 @@ import com.amazonaws.services.iot.client.AWSIotQos;
 import com.amazonaws.services.iot.client.AWSIotTimeoutException;
 import com.amazonaws.services.iot.client.AWSIotTopic;
 import com.amazonaws.services.iot.client.shadow.AbstractAwsIotDevice;
+import javax.net.ssl.SSLSocketFactory;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -73,6 +74,17 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
 
         try {
             connection = new AwsIotTlsConnection(this, keyStore, keyPassword);
+        } catch (AWSIotException e) {
+            throw new AwsIotRuntimeException(e);
+        }
+    }
+
+    protected AbstractAwsIotClient(String clientEndpoint, String clientId, SSLSocketFactory socketFactory) {
+        this.clientEndpoint = clientEndpoint;
+        this.clientId = clientId;
+        this.connectionType = AwsIotConnectionType.MQTT_OVER_TLS;
+        try {
+            this.connection = new AwsIotTlsConnection(this, socketFactory);
         } catch (AWSIotException e) {
             throw new AwsIotRuntimeException(e);
         }

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotTlsConnection.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotTlsConnection.java
@@ -21,6 +21,9 @@ import com.amazonaws.services.iot.client.AWSIotException;
 import com.amazonaws.services.iot.client.mqtt.AwsIotMqttConnection;
 import com.amazonaws.services.iot.client.util.AwsIotTlsSocketFactory;
 
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
 /**
  * This is a thin layer on top of {@link AwsIotMqttConnection} that provides a
  * TLS v1.2 based communication channel to the MQTT implementation.
@@ -30,6 +33,10 @@ public class AwsIotTlsConnection extends AwsIotMqttConnection {
     public AwsIotTlsConnection(AbstractAwsIotClient client, KeyStore keyStore, String keyPassword)
             throws AWSIotException {
         super(client, new AwsIotTlsSocketFactory(keyStore, keyPassword), "ssl://" + client.getClientEndpoint() + ":8883");
+    }
+
+    public AwsIotTlsConnection(AbstractAwsIotClient client, SSLSocketFactory socketFactory) throws AWSIotException {
+        super(client, new AwsIotTlsSocketFactory(socketFactory), "ssl://" + client.getClientEndpoint() + ":8883");
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-iot-device-sdk-java-pom</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <packaging>pom</packaging>
   <name>AWS IoT Device SDK for Java</name>
   <description>The AWS IoT Device SDK for Java provides Java APIs for devices to connect to AWS IoT service using the MQTT protocol. The SDK also provides support for AWS IoT specific features, such as Thing Shadow and Thing Shadow abstraction.</description>


### PR DESCRIPTION
Adds new constructor methods to provide a custom SocketFactory, if we don't want to use the `cacerts` truststore or the one pointed to by property ` javax.net.ssl.trustStore`. 