### PR TITLE
Adding MQTT over 443 using ALPN TLS extension

### DIFF
--- a/aws-iot-device-sdk-java/pom.xml
+++ b/aws-iot-device-sdk-java/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
       <version>[1.1.0]</version>
     </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+      <version>1.0.1</version>
+    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>target/generated-sources/delombok</sourceDirectory>

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/AWSIotMqttClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/AWSIotMqttClient.java
@@ -129,6 +129,38 @@ public class AWSIotMqttClient extends AbstractAwsIotClient {
     public AWSIotMqttClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword) {
         super(clientEndpoint, clientId, keyStore, keyPassword);
     }
+    /**
+     * Instantiates a new client using TLS 1.2 mutual authentication. Client
+     * certificate and private key are passed in through the {@link KeyStore}
+     * argument. The key password protecting the private key in the
+     * {@link KeyStore} is also required.
+     *
+     * @param clientEndpoint
+     *            the client endpoint in the form of {@code <account-specific
+     *            prefix>.iot.<aws-region>.amazonaws.com}. The account-specific
+     *            prefix can be found on the AWS IoT console or by using the
+     *            {@code describe-endpoint} command through the AWS command line
+     *            interface.
+     * @param clientPort
+     *            the client port, either 8883 or 443 (using ALPN over TLS)
+     * @param clientId
+     *            the client ID uniquely identify a MQTT connection. Two clients
+     *            with the same client ID are not allowed to be connected
+     *            concurrently to a same endpoint.
+     * @param keyStore
+     *            the key store containing the client X.509 certificate and
+     *            private key. The {@link KeyStore} object can be constructed
+     *            using X.509 certificate file and private key file created on
+     *            the AWS IoT console. For more details, please refer to the
+     *            README file of this SDK.
+     * @param keyPassword
+     *            the key password protecting the private key in the
+     *            {@code keyStore} argument.
+     */
+    public AWSIotMqttClient(String clientEndpoint, int clientPort, String clientId, KeyStore keyStore, String keyPassword) {
+        super(clientEndpoint, clientPort, clientId, keyStore, keyPassword);
+    }
+
 
     /**
      * Instantiates a new client using Secure WebSocket and AWS SigV4

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
@@ -48,6 +48,7 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
 
     protected final String clientId;
     protected final String clientEndpoint;
+    protected final int clientPort;
     protected final AwsIotConnectionType connectionType;
 
     protected int numOfClientThreads = AWSIotConfig.NUM_OF_CLIENT_THREADS;
@@ -67,8 +68,13 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
     private ScheduledExecutorService executionService;
 
     protected AbstractAwsIotClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword) {
+        this(clientEndpoint, 8883, clientId, keyStore, keyPassword);
+    }
+
+    protected AbstractAwsIotClient(String clientEndpoint, int clientPort, String clientId, KeyStore keyStore, String keyPassword) {
         this.clientEndpoint = clientEndpoint;
         this.clientId = clientId;
+        this.clientPort = clientPort;
         this.connectionType = AwsIotConnectionType.MQTT_OVER_TLS;
 
         try {
@@ -82,6 +88,7 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
             String awsSecretAccessKey, String sessionToken) {
         this.clientEndpoint = clientEndpoint;
         this.clientId = clientId;
+        this.clientPort = 443;
         this.connectionType = AwsIotConnectionType.MQTT_OVER_WEBSOCKET;
 
         try {
@@ -91,8 +98,9 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
         }
     }
 
-    AbstractAwsIotClient(String clientEndpoint, String clientId, AwsIotConnection connection) {
+    AbstractAwsIotClient(String clientEndpoint, int clientPort, String clientId, AwsIotConnection connection) {
         this.clientEndpoint = clientEndpoint;
+        this.clientPort = clientPort;
         this.clientId = clientId;
         this.connection = connection;
         this.connectionType = null;

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotTlsConnection.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotTlsConnection.java
@@ -29,7 +29,7 @@ public class AwsIotTlsConnection extends AwsIotMqttConnection {
 
     public AwsIotTlsConnection(AbstractAwsIotClient client, KeyStore keyStore, String keyPassword)
             throws AWSIotException {
-        super(client, new AwsIotTlsSocketFactory(keyStore, keyPassword), "ssl://" + client.getClientEndpoint() + ":8883");
+        super(client, new AwsIotTlsSocketFactory(keyStore, keyPassword), "ssl://" + client.getClientEndpoint() + ":" + client.getClientPort());
     }
 
 }


### PR DESCRIPTION
Trying to get the ball rolling on support for [MQTT over 443 with the ALPN extension](https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/).

[Conscrypt](https://github.com/google/conscrypt) seems to be the only library I can find that supports it so this PR is more of a suggestion than anything, I'm very open to other ways, especially if they are more portable.