### PR TITLE
Upgraded paho library to 1.2.0

### DIFF
--- a/aws-iot-device-sdk-java/pom.xml
+++ b/aws-iot-device-sdk-java/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-      <version>[1.1.0]</version>
+      <version>[1.2.0]</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Upgraded paho library to 1.2.0.

I have tested AWS SDK with new version of paho and it seems to be working: messages are getting published via WebSockets and TCP connections, Shadows are getting updated etc etc.

Signed-off-by: Rehan Shaukat <rehan.shaukat@gmail.com>