### PR TITLE
Prevent provided executor from being shut down

### DIFF
--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
@@ -66,6 +66,7 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
     private final AwsIotConnection connection;
 
     private ScheduledExecutorService executionService;
+    private boolean executionServiceOwner = false;
 
     protected AbstractAwsIotClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword,
                                    boolean enableSdkMetrics) {
@@ -141,6 +142,7 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
         synchronized (this) {
             if (executionService == null) {
                 executionService = Executors.newScheduledThreadPool(numOfClientThreads);
+                executionServiceOwner = true;
             }
         }
 
@@ -437,7 +439,9 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
         subscriptions.clear();
         devices.clear();
 
-        executionService.shutdown();
+        if (executionServiceOwner) {
+            executionService.shutdown();
+        }
     }
 
     public Future<?> scheduleTask(Runnable runnable) {


### PR DESCRIPTION
When an executor was provided, the AWSIoTClient took ownership.
So when it is closed it would also shut down the provided executor.

We do not think this is the expected behavior, as it is typically provided so it can be shared with other services which probably have their own lifecycle.