### PR TITLE
Sample to show how to set the username to allow for custom metrics

### DIFF
--- a/aws-iot-device-sdk-java-samples/src/main/java/com/amazonaws/services/iot/client/sample/pubSub/CustomMetricsSample.java
+++ b/aws-iot-device-sdk-java-samples/src/main/java/com/amazonaws/services/iot/client/sample/pubSub/CustomMetricsSample.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.sample.pubSub;
+
+import com.amazonaws.services.iot.client.*;
+import com.amazonaws.services.iot.client.sample.sampleUtil.CommandArguments;
+import com.amazonaws.services.iot.client.sample.sampleUtil.SampleUtil;
+import com.amazonaws.services.iot.client.sample.sampleUtil.SampleUtil.KeyStorePasswordPair;
+
+/**
+ * This is an example that uses {@link AWSIotMqttClient} to subscribe to a topic and
+ * publish messages to it. Both blocking and non-blocking publishing are
+ * demonstrated in this example.
+ */
+public class CustomMetricsSample {
+    private static final String TestTopic = "sdk/test/java";
+    private static final AWSIotQos TestTopicQos = AWSIotQos.QOS0;
+
+    private static AWSIotMqttClient awsIotClient;
+
+    public static void setClient(AWSIotMqttClient client) {
+        awsIotClient = client;
+    }
+
+    public static class BlockingPublisher implements Runnable {
+        private final AWSIotMqttClient awsIotClient;
+
+        public BlockingPublisher(AWSIotMqttClient awsIotClient) {
+            this.awsIotClient = awsIotClient;
+        }
+
+        @Override
+        public void run() {
+            long counter = 1;
+
+            while (true) {
+                String payload = "hello from blocking publisher - " + (counter++);
+                try {
+                    awsIotClient.publish(TestTopic, payload);
+                } catch (AWSIotException e) {
+                    System.out.println(System.currentTimeMillis() + ": publish failed for " + payload);
+                }
+                System.out.println(System.currentTimeMillis() + ": >>> " + payload);
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    System.out.println(System.currentTimeMillis() + ": BlockingPublisher was interrupted");
+                    return;
+                }
+            }
+        }
+    }
+
+    public static class NonBlockingPublisher implements Runnable {
+        private final AWSIotMqttClient awsIotClient;
+
+        public NonBlockingPublisher(AWSIotMqttClient awsIotClient) {
+            this.awsIotClient = awsIotClient;
+        }
+
+        @Override
+        public void run() {
+            long counter = 1;
+
+            while (true) {
+                String payload = "hello from non-blocking publisher - " + (counter++);
+                AWSIotMessage message = new NonBlockingPublishListener(TestTopic, TestTopicQos, payload);
+                try {
+                    awsIotClient.publish(message);
+                } catch (AWSIotException e) {
+                    System.out.println(System.currentTimeMillis() + ": publish failed for " + payload);
+                }
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    System.out.println(System.currentTimeMillis() + ": NonBlockingPublisher was interrupted");
+                    return;
+                }
+            }
+        }
+    }
+
+    private static void initClient(CommandArguments arguments) {
+        String clientEndpoint = arguments.getNotNull("clientEndpoint", SampleUtil.getConfig("clientEndpoint"));
+        String clientId = arguments.getNotNull("clientId", SampleUtil.getConfig("clientId"));
+
+        String certificateFile = arguments.get("certificateFile", SampleUtil.getConfig("certificateFile"));
+        String privateKeyFile = arguments.get("privateKeyFile", SampleUtil.getConfig("privateKeyFile"));
+
+        if (awsIotClient == null && certificateFile != null && privateKeyFile != null) {
+            String algorithm = arguments.get("keyAlgorithm", SampleUtil.getConfig("keyAlgorithm"));
+
+            KeyStorePasswordPair pair = SampleUtil.getKeyStorePasswordPair(certificateFile, privateKeyFile, algorithm);
+
+            awsIotClient = new AWSIotMqttClient(clientEndpoint, clientId, pair.keyStore, pair.keyPassword);
+        }
+
+        if (awsIotClient == null) {
+            String awsAccessKeyId = arguments.get("awsAccessKeyId", SampleUtil.getConfig("awsAccessKeyId"));
+            String awsSecretAccessKey = arguments.get("awsSecretAccessKey", SampleUtil.getConfig("awsSecretAccessKey"));
+            String sessionToken = arguments.get("sessionToken", SampleUtil.getConfig("sessionToken"));
+
+            if (awsAccessKeyId != null && awsSecretAccessKey != null) {
+                awsIotClient = new AWSIotMqttClient(clientEndpoint, clientId, awsAccessKeyId, awsSecretAccessKey,
+                        sessionToken);
+            }
+        }
+
+        if (awsIotClient == null) {
+            throw new IllegalArgumentException("Failed to construct client due to missing certificate or credentials.");
+        }
+    }
+
+    public static void main(String args[]) throws InterruptedException, AWSIotException, AWSIotTimeoutException {
+        CommandArguments arguments = CommandArguments.parse(args);
+        initClient(arguments);
+
+        awsIotClient.setUsernameMetricString("?SDK=JavaCustomMetrics");
+        awsIotClient.connect();
+
+        AWSIotTopic topic = new TestTopicListener(TestTopic, TestTopicQos);
+        awsIotClient.subscribe(topic, true);
+
+        Thread blockingPublishThread = new Thread(new BlockingPublisher(awsIotClient));
+        Thread nonBlockingPublishThread = new Thread(new NonBlockingPublisher(awsIotClient));
+
+        blockingPublishThread.start();
+        nonBlockingPublishThread.start();
+
+        blockingPublishThread.join();
+        nonBlockingPublishThread.join();
+    }
+
+}

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
@@ -120,6 +120,10 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
         this(clientEndpoint, clientId, connection, true);
     }
 
+    public void setUsernameMetricString(String usernameMetricString) {
+        connection.setUsernameMetricString(usernameMetricString);
+    }
+
     public void updateCredentials(String awsAccessKeyId, String awsSecretAccessKey, String sessionToken) {
         this.connection.updateCredentials(awsAccessKeyId, awsSecretAccessKey, sessionToken);
     }

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotConnection.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotConnection.java
@@ -467,4 +467,5 @@ public abstract class AwsIotConnection implements AwsIotConnectionCallback {
         }, getRetryDelay());
     }
 
+    public abstract void setUsernameMetricString(String usernameMetricString);
 }

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/mqtt/AwsIotMqttConnection.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/mqtt/AwsIotMqttConnection.java
@@ -43,10 +43,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class AwsIotMqttConnection extends AwsIotConnection {
-
-    private static final String USERNAME_METRIC_STRING = "?SDK=Java&Version=1.2.0";
     private final SocketFactory socketFactory;
-
+    private String usernameMetricString = null;
     private MqttAsyncClient mqttClient;
     private AwsIotMqttMessageListener messageListener;
     private AwsIotMqttClientListener clientListener;
@@ -147,8 +145,8 @@ public class AwsIotMqttConnection extends AwsIotConnection {
         options.setCleanSession(true);
         options.setConnectionTimeout(client.getConnectionTimeout() / 1000);
         options.setKeepAliveInterval(client.getKeepAliveInterval() / 1000);
-        if(client.isClientEnableMetrics()) {
-            options.setUserName(USERNAME_METRIC_STRING);
+        if (client.isClientEnableMetrics()) {
+            options.setUserName(getUsernameMetricString());
         }
 
         Set<String> serverUris = getServerUris();
@@ -167,4 +165,16 @@ public class AwsIotMqttConnection extends AwsIotConnection {
         return options;
     }
 
+    private String getUsernameMetricString() {
+        if (usernameMetricString == null) {
+            return "?SDK=Java&Version=1.2.0";
+        }
+
+        return usernameMetricString;
+    }
+
+    @Override
+    public void setUsernameMetricString(String usernameMetricString) {
+        this.usernameMetricString = usernameMetricString;
+    }
 }


### PR DESCRIPTION
This allows customers to customize the metrics sent by the client to AWS IoT and includes a sample of how it can be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
