### PR TITLE
Fix CVE-2019-14379: update jackson-databind to 2.9.9.3

### DIFF
--- a/aws-iot-device-sdk-java/pom.xml
+++ b/aws-iot-device-sdk-java/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.paho</groupId>


### PR DESCRIPTION
CVE-2019-14379: SubTypeValidator.java in FasterXML jackson-databind before 2.9.9.2 mishandles default typing when ehcache is used, leading to remote code execution.

This vulnerability is marked as Critical in https://nvd.nist.gov/vuln/detail/CVE-2019-14379

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
