### PR TITLE
Greengrass Core support

### DIFF
--- a/aws-iot-device-sdk-java-samples/src/main/java/com/amazonaws/services/iot/client/sample/greengrass/BasicDiscovery.java
+++ b/aws-iot-device-sdk-java-samples/src/main/java/com/amazonaws/services/iot/client/sample/greengrass/BasicDiscovery.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.sample.greengrass;
+
+import com.amazonaws.services.iot.client.*;
+import com.amazonaws.services.iot.client.greengrass.ConnectivityInfo;
+import com.amazonaws.services.iot.client.greengrass.CoreConnectivityInfo;
+import com.amazonaws.services.iot.client.greengrass.DiscoveryInfo;
+import com.amazonaws.services.iot.client.greengrass.DiscoveryInfoProvider;
+import com.amazonaws.services.iot.client.sample.sampleUtil.CommandArguments;
+import com.amazonaws.services.iot.client.sample.sampleUtil.SampleUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.amazonaws.services.iot.client.sample.sampleUtil.SampleUtil.getConfig;
+
+public class BasicDiscovery {
+
+    private static final ObjectMapper ObjectMapper = new ObjectMapper();
+    private static final String TestTopic = "sdk/test/java";
+    private static final AWSIotQos TestTopicQos = AWSIotQos.QOS0;
+
+    private static String appMode;
+    private static AWSIotMqttClient awsIotMqttClient;
+
+    private static void initClient(final CommandArguments args) throws CertificateException {
+        // Read in command-line parameters
+        String clientEndpoint = args.getNotNull("clientEndpoint", getConfig("clientEndpoint"));
+        String thingName = args.getNotNull("thingName", getConfig("thingName"));
+
+        String certificateFile = args.getNotNull("certificateFile", getConfig("certificateFile"));
+        String privateKeyFile = args.getNotNull("privateKeyFile", getConfig("privateKeyFile"));
+        String algorithm = args.get("keyAlgorithm", getConfig("keyAlgorithm"));
+        if (certificateFile == null || privateKeyFile == null) {
+            throw new IllegalArgumentException(
+                "Missing credentials for authentication, you must specify --certificateFile and --privateKeyFile args.");
+        }
+
+        SampleUtil.KeyStorePasswordPair pair = SampleUtil.getKeyStorePasswordPair(
+            certificateFile, privateKeyFile, algorithm);
+
+        appMode = args.getNotNull("mode", "both");
+        if (!Arrays.asList("both", "publish", "subscribe").contains(appMode)) {
+            throw new IllegalArgumentException(String.format(
+                "Unknown --mode option '%s'. Must be one of [\"both\", \"publish\", \"subscribe\"]", appMode));
+        }
+
+        awsIotMqttClient = connectToGGC(clientEndpoint, thingName, pair.keyStore, pair.keyPassword);
+    }
+
+    private static AWSIotMqttClient connectToGGC(String clientEndpoint, String thingName,
+                                                 KeyStore keyStore, String keyPassword) throws CertificateException {
+        // Discover GGCs
+        DiscoveryInfoProvider discoveryInfoProvider =
+            new DiscoveryInfoProvider(clientEndpoint, 8443, 10, keyStore, keyPassword);
+        DiscoveryInfo discoveryInfo = discoveryInfoProvider.discover(thingName);
+
+        // We only pick the first ca and core info
+        CoreConnectivityInfo core = discoveryInfo.getAllCores().get(0);
+        List<Certificate> trustedCAs = discoveryInfo.getAllCas();
+
+        // Iterate through all connection options for the core and use the first successful one
+        for (ConnectivityInfo connectivityInfo : core.getConnectivity()) {
+            final String coreEndpoint = connectivityInfo.getHostAddress() + ":" + connectivityInfo.getPortNumber();
+            System.out.println("Trying to connect to core at " + coreEndpoint);
+
+            AWSIotMqttClient client = new AWSIotMqttClient(coreEndpoint, thingName, keyStore, keyPassword, trustedCAs);
+            client.setMaxConnectionRetries(0);
+
+            try {
+                client.connect();
+
+                return client;
+            } catch (AWSIotException e) {
+                System.err.println("Error in connect!");
+                System.err.println("Error message: " + e.getMessage());
+            }
+        }
+
+        throw new RuntimeException(
+            String.format("Cannot connect to core %s.", core.getThingArn()));
+    }
+
+    public static void main(String[] args) throws Exception {
+        CommandArguments arguments = CommandArguments.parse(args);
+        initClient(arguments);
+
+        if ("both".equals(appMode) || "subscribe".equals(appMode)) {
+            awsIotMqttClient.subscribe(new AWSIotTopic(TestTopic, TestTopicQos) {
+                @Override
+                public void onMessage(AWSIotMessage message) {
+                    System.out.printf("Received message on topic %s: %s\n",
+                        message.getTopic(), message.getStringPayload());
+                }
+            });
+        }
+
+        long loopCount = 0;
+        while (true) {
+            if ("both".equals(appMode) || "publish".equals(appMode)) {
+                final Map<String, Object> msg = new HashMap<>();
+                msg.put("message", "Hello World!");
+                msg.put("sequence", loopCount++);
+                final String json = ObjectMapper.writeValueAsString(msg);
+
+                awsIotMqttClient.publish(TestTopic, AWSIotQos.QOS0, json);
+                if ("publish".equals(appMode)) {
+                    System.out.printf("Published topic %s: %s\n", TestTopic, json);
+                }
+            }
+
+            Thread.sleep(1000);
+        }
+    }
+
+}

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/AWSIotMqttClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/AWSIotMqttClient.java
@@ -19,6 +19,8 @@ import com.amazonaws.services.iot.client.core.AbstractAwsIotClient;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.List;
 
 /**
  * This class is the main interface of the AWS IoT Java library. It provides
@@ -128,7 +130,44 @@ public class AWSIotMqttClient extends AbstractAwsIotClient {
      *            {@code keyStore} argument.
      */
     public AWSIotMqttClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword) {
-        super(clientEndpoint, clientId, keyStore, keyPassword);
+        super(clientEndpoint, clientId, keyStore, keyPassword, null);
+    }
+
+    /**
+     * Instantiates a new client using TLS 1.2 mutual authentication. Client
+     * certificate and private key are passed in through the {@link KeyStore}
+     * argument. The key password protecting the private key in the
+     * {@link KeyStore} is also required.
+     *
+     * @param clientEndpoint
+     *            the client endpoint in the form of {@code <account-specific
+     *            prefix>.iot.<aws-region>.amazonaws.com}. The account-specific
+     *            prefix can be found on the AWS IoT console or by using the
+     *            {@code describe-endpoint} command through the AWS command line
+     *            interface.
+     * @param clientId
+     *            the client ID uniquely identify a MQTT connection. Two clients
+     *            with the same client ID are not allowed to be connected
+     *            concurrently to a same endpoint.
+     * @param keyStore
+     *            the key store containing the client X.509 certificate and
+     *            private key. The {@link KeyStore} object can be constructed
+     *            using X.509 certificate file and private key file created on
+     *            the AWS IoT console. For more details, please refer to the
+     *            README file of this SDK.
+     * @param keyPassword
+     *            the key password protecting the private key in the
+     *            {@code keyStore} argument.
+     * @param trustedCaList
+     *            the CA that should be trusted when establishing the MQTT
+     *            connection. This is NOT in addition to the normal system-wide
+     *            trusted certificates. Normally used with Greengrass discovery.
+     *            Ignored if NULL.
+     *            {@code keyStore} argument.
+     */
+    public AWSIotMqttClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword,
+                            List<Certificate> trustedCaList) {
+        super(clientEndpoint, clientId, keyStore, keyPassword, trustedCaList);
     }
 
     /**

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AbstractAwsIotClient.java
@@ -38,6 +38,9 @@ import com.amazonaws.services.iot.client.shadow.AbstractAwsIotDevice;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.security.cert.Certificate;
+import java.util.List;
+
 /**
  * The actual implementation of {@code AWSIotMqttClient}.
  */
@@ -73,22 +76,23 @@ public abstract class AbstractAwsIotClient implements AwsIotConnectionCallback {
     private ScheduledExecutorService executionService;
 
     protected AbstractAwsIotClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword,
-                                   boolean enableSdkMetrics) {
+                                   List<Certificate> trustedCaList, boolean enableSdkMetrics) {
         this.clientEndpoint = clientEndpoint;
         this.clientId = clientId;
         this.connectionType = AwsIotConnectionType.MQTT_OVER_TLS;
         this.clientEnableMetrics = enableSdkMetrics;
 
         try {
-            connection = new AwsIotTlsConnection(this, keyStore, keyPassword);
+            connection = new AwsIotTlsConnection(this, keyStore, keyPassword, trustedCaList);
         } catch (AWSIotException e) {
             throw new AwsIotRuntimeException(e);
         }
     }
-    
-    protected AbstractAwsIotClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword) {
+
+    protected AbstractAwsIotClient(String clientEndpoint, String clientId, KeyStore keyStore, String keyPassword,
+                                   List<Certificate> trustedCaList) {
         // Enable Metrics by default
-        this(clientEndpoint, clientId, keyStore, keyPassword, true);
+        this(clientEndpoint, clientId, keyStore, keyPassword, trustedCaList, true);
     }
 
     protected AbstractAwsIotClient(String clientEndpoint, String clientId, String awsAccessKeyId,

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotTlsConnection.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/core/AwsIotTlsConnection.java
@@ -16,7 +16,8 @@
 package com.amazonaws.services.iot.client.core;
 
 import java.security.KeyStore;
-import javax.net.SocketFactory;
+import java.security.cert.Certificate;
+import java.util.List;
 import javax.net.ssl.SSLSocketFactory;
 
 import com.amazonaws.services.iot.client.AWSIotException;
@@ -29,13 +30,13 @@ import com.amazonaws.services.iot.client.util.AwsIotTlsSocketFactory;
  */
 public class AwsIotTlsConnection extends AwsIotMqttConnection {
 
-    public AwsIotTlsConnection(AbstractAwsIotClient client, KeyStore keyStore, String keyPassword)
-            throws AWSIotException {
-        super(client, new AwsIotTlsSocketFactory(keyStore, keyPassword), "ssl://" + client.getClientEndpoint() + ":" + client.getPort());
+    public AwsIotTlsConnection(AbstractAwsIotClient client, KeyStore keyStore, String keyPassword,
+                               List<Certificate> trustedCaList) throws AWSIotException {
+        super(client, new AwsIotTlsSocketFactory(keyStore, keyPassword, trustedCaList), "ssl://" + client.getClientEndpoint() + ":" + client.getPort());
     }
 
     public AwsIotTlsConnection(AbstractAwsIotClient client, SSLSocketFactory socketFactory) throws AWSIotException {
         super(client, new AwsIotTlsSocketFactory(socketFactory), "ssl://" + client.getClientEndpoint() + ":" + client.getPort());
     }
-    
+
 }

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/ConnectivityInfo.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/ConnectivityInfo.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.greengrass;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Class the stores one set of the connectivity information.
+ */
+public class ConnectivityInfo implements Serializable {
+
+    /**
+     * <p>
+     * Connectivity Information Id.
+     * </p>
+     */
+    @JsonProperty(value = "Id")
+    private String id;
+
+    /**
+     * <p>
+     * Host address.
+     * </p>
+     */
+    @JsonProperty(value = "HostAddress")
+    private String hostAddress;
+
+    /**
+     * <p>
+     * Port number.
+     * </p>
+     */
+    @JsonProperty(value = "PortNumber")
+    private Integer portNumber;
+
+    /**
+     * <p>
+     * Metadata string.
+     * </p>
+     */
+    @JsonProperty(value = "Metadata")
+    private String metadata;
+
+    /**
+     * <p>
+     * Connectivity Information Id.
+     * </p>
+     *
+     * @return Connectivity Information Id.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * <p>
+     * Connectivity Information Id.
+     * </p>
+     *
+     * @param id
+     *            Connectivity Information Id.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * <p>
+     * Connectivity Information Id.
+     * </p>
+     *
+     * @param id
+     *            Connectivity Information Id.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public ConnectivityInfo withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Host address.
+     * </p>
+     *
+     * @return Host address.
+     */
+    public String getHostAddress() {
+        return hostAddress;
+    }
+
+    /**
+     * <p>
+     * Host address.
+     * </p>
+     *
+     * @param hostAddress
+     *            Host address.
+     */
+    public void setHostAddress(String hostAddress) {
+        this.hostAddress = hostAddress;
+    }
+
+    /**
+     * <p>
+     * Host address.
+     * </p>
+     *
+     * @param hostAddress
+     *            Host address.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public ConnectivityInfo withHostAddress(String hostAddress) {
+        this.hostAddress = hostAddress;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Port number.
+     * </p>
+     *
+     * @return Port number.
+     */
+    public Integer getPortNumber() {
+        return portNumber;
+    }
+
+    /**
+     * <p>
+     * Port number.
+     * </p>
+     *
+     * @param portNumber
+     *            Port number.
+     */
+    public void setPortNumber(Integer portNumber) {
+        this.portNumber = portNumber;
+    }
+
+    /**
+     * <p>
+     * Port number.
+     * </p>
+     *
+     * @param portNumber
+     *            Port number.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public ConnectivityInfo withPortNumber(Integer portNumber) {
+        this.portNumber = portNumber;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Metadata string.
+     * </p>
+     *
+     * @return Metadata string.
+     */
+    public String getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * <p>
+     * Metadata string.
+     * </p>
+     *
+     * @param metadata
+     *            Metadata string.
+     */
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * <p>
+     * Metadata string.
+     * </p>
+     *
+     * @param metadata
+     *            Metadata string.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public ConnectivityInfo withMetadata(String metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, hostAddress, portNumber, metadata);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConnectivityInfo that = (ConnectivityInfo) o;
+        return Objects.equals(id, that.id) &&
+            Objects.equals(hostAddress, that.hostAddress) &&
+            Objects.equals(portNumber, that.portNumber) &&
+            Objects.equals(metadata, that.metadata);
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     *
+     * @return A string representation of this object.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getId() != null)
+            sb.append("Id: ").append(getId()).append(',');
+        if (getHostAddress() != null)
+            sb.append("HostAddress: ").append(getHostAddress()).append(',');
+        if (getPortNumber() != null)
+            sb.append("PortNumber: ").append(getPortNumber()).append(',');
+        if (getMetadata() != null)
+            sb.append("Metadata: ").append(getMetadata());
+        sb.append("}");
+        return sb.toString();
+    }
+
+}

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/CoreConnectivityInfo.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/CoreConnectivityInfo.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.greengrass;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class that stores the connectivity information for a Greengrass core.
+ */
+public class CoreConnectivityInfo implements Serializable {
+
+    /**
+     * <p>
+     * Thing arn for this Greengrass core.
+     * </p>
+     */
+    @JsonProperty(value = "thingArn")
+    private String thingArn;
+
+    /**
+     * <p>
+     * The list of connectivity information that this Greengrass core has.
+     * </p>
+     */
+    @JsonProperty(value = "Connectivity")
+    private List<ConnectivityInfo> connectivity;
+
+    /**
+     * <p>
+     * Thing arn for this Greengrass core.
+     * </p>
+     *
+     * @return Thing arn for this Greengrass core.
+     */
+    public String getThingArn() {
+        return thingArn;
+    }
+
+    /**
+     * <p>
+     * Thing arn for this Greengrass core.
+     * </p>
+     *
+     * @param thingArn
+     *            Thing arn for this Greengrass core.
+     */
+    public void setThingArn(String thingArn) {
+        this.thingArn = thingArn;
+    }
+
+    /**
+     * <p>
+     * Thing arn for this Greengrass core.
+     * </p>
+     *
+     * @param thingArn
+     *            Thing arn for this Greengrass core.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public CoreConnectivityInfo withThingArn(String thingArn) {
+        this.thingArn = thingArn;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The list of connectivity information that this Greengrass core has.
+     * </p>
+     *
+     * @return The list of connectivity information.
+     */
+    public List<ConnectivityInfo> getConnectivity() {
+        return connectivity;
+    }
+
+    /**
+     * <p>
+     * The list of connectivity information that this Greengrass core has.
+     * </p>
+     *
+     * @param connectivity
+     *            The list of connectivity information.
+     */
+    public void setConnectivity(List<ConnectivityInfo> connectivity) {
+        this.connectivity = connectivity;
+    }
+
+    /**
+     * <p>
+     * The list of connectivity information that this Greengrass core has.
+     * </p>
+     *
+     * @param connectivity
+     *            The list of connectivity information.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public CoreConnectivityInfo withConnectivity(List<ConnectivityInfo> connectivity) {
+        this.connectivity = connectivity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The list of connectivity information that this Greengrass core has.
+     * </p>
+     *
+     * @param connectivity
+     *            The list of connectivity information.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public CoreConnectivityInfo withConnectivity(ConnectivityInfo ... connectivity) {
+        this.connectivity = Arrays.asList(connectivity);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(thingArn, connectivity);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CoreConnectivityInfo that = (CoreConnectivityInfo) o;
+        return Objects.equals(thingArn, that.thingArn) &&
+            Objects.equals(connectivity, that.connectivity);
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     *
+     * @return A string representation of this object.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getThingArn() != null)
+            sb.append("thingArn: ").append(getThingArn()).append(',');
+        if (getConnectivity() != null)
+            sb.append("Connectivity: ").append(getConnectivity());
+        sb.append("}");
+        return sb.toString();
+    }
+
+}

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/DiscoveryException.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/DiscoveryException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.greengrass;
+
+/**
+ * Base exception for all exceptions thrown while discovery Greengrass Core
+ */
+public class DiscoveryException extends RuntimeException {
+
+    /**
+     * Constructs a new DiscoveryException
+     */
+    public DiscoveryException() {
+    }
+
+    /**
+     * Constructs a new DiscoveryException with the specified error message.
+     *
+     * @param message
+     *            describes the error encountered.
+     */
+    public DiscoveryException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new DiscoveryException with the specified error message
+     * and cause.
+     *
+     * @param message
+     *            describes the error encountered.
+     * @param cause
+     *            the cause.
+     */
+    public DiscoveryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/DiscoveryInfo.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/DiscoveryInfo.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.greengrass;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class that stores the discovery information coming back from the discovery request.
+ */
+public class DiscoveryInfo implements Serializable {
+
+    /**
+     * <p>
+     * The list of AWS Greengrass groups that device is a member of.
+     * </p>
+     */
+    @JsonProperty(value = "GGGroups")
+    private List<GroupConnectivityInfo> ggGroups;
+
+    /**
+     * <p>
+     * The list of AWS Greengrass groups that device is a member of.
+     * </p>
+     *
+     * @return The list of AWS Greengrass groups.
+     */
+    public List<GroupConnectivityInfo> getGgGroups() {
+        return ggGroups;
+    }
+
+    /**
+     * <p>
+     * The list of AWS Greengrass groups that device is a member of.
+     * </p>
+     *
+     * @param ggGroups
+     *            The list of AWS Greengrass groups.
+     */
+    public void setGgGroups(List<GroupConnectivityInfo> ggGroups) {
+        this.ggGroups = ggGroups;
+    }
+
+    /**
+     * <p>
+     * The list of AWS Greengrass groups that device is a member of.
+     * </p>
+     *
+     * @param ggGroups
+     *            The list of AWS Greengrass groups.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public DiscoveryInfo withGgGroups(List<GroupConnectivityInfo> ggGroups) {
+        this.ggGroups = ggGroups;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The list of AWS Greengrass groups that device is a member of.
+     * </p>
+     *
+     * @param ggGroups
+     *            The list of AWS Greengrass groups.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public DiscoveryInfo withGgGroups(GroupConnectivityInfo... ggGroups) {
+        this.ggGroups = Arrays.asList(ggGroups);
+        return this;
+    }
+
+    /**
+     * <p>
+     * Used to retrieve the list of CAs for this discovery information
+     * </p>
+     *
+     * @return List Certificate objects
+     * @throws CertificateException on parsing errors.
+     */
+    public List<Certificate> getAllCas() throws CertificateException {
+        if (ggGroups == null) {
+            return Collections.emptyList();
+        }
+
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        List<Certificate> cas = new ArrayList<>();
+        for (GroupConnectivityInfo group : ggGroups) {
+            for (String ca : group.getCas()) {
+                cas.addAll(factory.generateCertificates(new ByteArrayInputStream(ca.getBytes())));
+            }
+        }
+
+        return cas;
+    }
+
+    /**
+     * <p>
+     * Used to retrieve the list of CoreConnectivityInfo object for this discovery information.
+     * </p>
+     *
+     * @return List CoreConnectivityInfo objects
+     */
+    public List<CoreConnectivityInfo> getAllCores() {
+        if (ggGroups == null) {
+            return Collections.emptyList();
+        }
+
+        List<CoreConnectivityInfo> cores = new ArrayList<>();
+        for (GroupConnectivityInfo group : ggGroups) {
+            cores.addAll(group.getCores());
+        }
+
+        return cores;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ggGroups);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DiscoveryInfo that = (DiscoveryInfo) o;
+        return Objects.equals(ggGroups, that.ggGroups);
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     *
+     * @return A string representation of this object.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getGgGroups() != null)
+            sb.append("GGGroups: ").append(getGgGroups());
+        sb.append("}");
+        return sb.toString();
+    }
+
+}

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/DiscoveryInfoProvider.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/DiscoveryInfoProvider.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.greengrass;
+
+import com.amazonaws.services.iot.client.AWSIotException;
+import com.amazonaws.services.iot.client.core.AwsIotRuntimeException;
+import com.amazonaws.services.iot.client.util.AwsIotTlsSocketFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyStore;
+import java.util.logging.Logger;
+
+/**
+ * The class that provides functionality to perform a Greengrass discovery process to the cloud.
+ */
+public class DiscoveryInfoProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(DiscoveryInfoProvider.class.getName());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final String endpoint;
+    private final Integer port;
+    private final Integer timeoutSec;
+    private final SSLSocketFactory sslSocketFactory;
+
+    /**
+     * <p>
+     * Constructs a new instance of DiscoveryInfoProvider with port it is 8443 by default
+     * and timeout 120 seconds by default.
+     * </p>
+     *
+     * @param endpoint
+     *            the client endpoint in the form of {@code <account-specific
+     *            prefix>.iot.<aws-region>.amazonaws.com}. The account-specific
+     *            prefix can be found on the AWS IoT console or by using the
+     *            {@code describe-endpoint} command through the AWS command line
+     *            interface.
+     * @param keyStore
+     *            the key store containing the client X.509 certificate and
+     *            private key. The {@link KeyStore} object can be constructed
+     *            using X.509 certificate file and private key file created on
+     *            the AWS IoT console. For more details, please refer to the
+     *            README file of this SDK.
+     * @param keyPassword
+     *            the key password protecting the private key in the
+     *            {@code keyStore} argument.
+     */
+    public DiscoveryInfoProvider(String endpoint, KeyStore keyStore, String keyPassword) {
+        this(endpoint, 8443, keyStore, keyPassword);
+    }
+
+    /**
+     * <p>
+     * Constructs a new instance of DiscoveryInfoProvider with timeout 120 seconds by default.
+     * </p>
+     *
+     * @param endpoint
+     *            the client endpoint in the form of {@code <account-specific
+     *            prefix>.iot.<aws-region>.amazonaws.com}. The account-specific
+     *            prefix can be found on the AWS IoT console or by using the
+     *            {@code describe-endpoint} command through the AWS command line
+     *            interface.
+     * @param port
+     *            the port number to connect to. For discovery purpose,
+     *            it is 8443 by default.
+     * @param keyStore
+     *            the key store containing the client X.509 certificate and
+     *            private key. The {@link KeyStore} object can be constructed
+     *            using X.509 certificate file and private key file created on
+     *            the AWS IoT console. For more details, please refer to the
+     *            README file of this SDK.
+     * @param keyPassword
+     *            the key password protecting the private key in the
+     *            {@code keyStore} argument.
+     */
+    public DiscoveryInfoProvider(String endpoint, Integer port, KeyStore keyStore, String keyPassword) {
+        this(endpoint, port, 120, keyStore, keyPassword);
+    }
+
+    /**
+     * <p>
+     * Constructs a new instance of DiscoveryInfoProvider.
+     * </p>
+     *
+     * @param endpoint
+     *            the client endpoint in the form of {@code <account-specific
+     *            prefix>.iot.<aws-region>.amazonaws.com}. The account-specific
+     *            prefix can be found on the AWS IoT console or by using the
+     *            {@code describe-endpoint} command through the AWS command line
+     *            interface.
+     * @param port
+     *            the port number to connect to. For discovery purpose,
+     *            it is 8443 by default.
+     * @param timeoutSec
+     *            time out configuration in seconds to consider a discovery
+     *            request sending/response waiting has been timed out.
+     * @param keyStore
+     *            the key store containing the client X.509 certificate and
+     *            private key. The {@link KeyStore} object can be constructed
+     *            using X.509 certificate file and private key file created on
+     *            the AWS IoT console. For more details, please refer to the
+     *            README file of this SDK.
+     * @param keyPassword
+     *            the key password protecting the private key in the
+     *            {@code keyStore} argument.
+     */
+    public DiscoveryInfoProvider(String endpoint, Integer port, Integer timeoutSec, KeyStore keyStore, String keyPassword) {
+        this.endpoint = endpoint;
+        this.port = port;
+        this.timeoutSec = timeoutSec;
+
+        try {
+            this.sslSocketFactory = new AwsIotTlsSocketFactory(keyStore, keyPassword, null);
+        } catch (AWSIotException e) {
+            throw new AwsIotRuntimeException(e);
+        }
+    }
+
+    /**
+     * <p>
+     * Perform the discovery request for the given Greengrass aware device thing name.
+     * </p>
+     *
+     * @param thingName
+     *            greengrass aware device thing name.
+     * @return DiscoveryInfo object.
+     * @throws DiscoveryException unable discover thing.
+     */
+    public DiscoveryInfo discover(String thingName) throws DiscoveryException {
+        LOGGER.info("Starting discover request...");
+        LOGGER.info("Endpoint: " + endpoint + ":" + port);
+        LOGGER.info("Target thing: " + thingName);
+
+        try {
+            URL discoveryUrl = makeDiscoveryURL(endpoint, port, thingName);
+
+            HttpsURLConnection connection = (HttpsURLConnection) discoveryUrl.openConnection();
+            connection.setConnectTimeout(timeoutSec * 1000);
+            connection.setSSLSocketFactory(sslSocketFactory);
+
+            return parseResponse(DiscoveryInfo.class, connection.getInputStream());
+        } catch (IOException e) {
+            final String message = e.getMessage();
+            if (message.contains("HTTP response code: 403")) {
+                throw new DiscoveryException("Discovery Info for Thing Not Found", e);
+            } else if (message.contains("certificate_unknown")) {
+                throw new DiscoveryException("Device Certificate Not Known to AWS IoT", e);
+            } else {
+                throw new DiscoveryException(
+                    "Occurred I/O exception while retrieve Discover Information from AWS IoT Greengrass", e);
+            }
+        }
+    }
+
+    private static URL makeDiscoveryURL(String endpoint, Integer port, String thingName) {
+        final String url = String.format(
+            "https://%s:%s/greengrass/discover/thing/%s", endpoint, port, thingName);
+
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new DiscoveryException("Provided malformed discovery URL", e);
+        }
+    }
+
+    private static <T> T parseResponse(Class<T> clazz, InputStream object) throws DiscoveryException {
+        try {
+            return OBJECT_MAPPER.readValue(object, clazz);
+        } catch (Exception e) {
+            throw new DiscoveryException("Unable to de-serialize bytes into object", e);
+        }
+    }
+
+}

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/GroupConnectivityInfo.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/greengrass/GroupConnectivityInfo.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.iot.client.greengrass;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class that stores the connectivity information for a specific Greengrass group.
+ */
+public class GroupConnectivityInfo implements Serializable {
+
+    /**
+     * <p>
+     * Id for this Greengrass group.
+     * </p>
+     */
+    @JsonProperty(value = "GGGroupId")
+    private String ggGroupId;
+
+    /**
+     * <p>
+     * A list of Greengrass cores that belong to this Greengrass group.
+     * </p>
+     */
+    @JsonProperty(value = "Cores")
+    private List<CoreConnectivityInfo> cores;
+
+    /**
+     * <p>
+     * A list of CA content strings for this Greengrass group.
+     * </p>
+     */
+    @JsonProperty(value = "CAs")
+    private List<String> cas;
+
+    /**
+     * <p>
+     * Id for this Greengrass group.
+     * </p>
+     *
+     * @return Id for this Greengrass group.
+     */
+    public String getGgGroupId() {
+        return ggGroupId;
+    }
+
+    /**
+     * <p>
+     * Id for this Greengrass group.
+     * </p>
+     *
+     * @param ggGroupId
+     *            Id for this Greengrass group.
+     */
+    public void setGgGroupId(String ggGroupId) {
+        this.ggGroupId = ggGroupId;
+    }
+
+    /**
+     * <p>
+     * Id for this Greengrass group.
+     * </p>
+     *
+     * @param ggGroupId
+     *            Id for this Greengrass group.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public GroupConnectivityInfo withGgGroupId(String ggGroupId) {
+        this.ggGroupId = ggGroupId;
+        return this;
+    }
+
+    /**
+     * <p>
+     * A list of Greengrass cores that belong to this Greengrass group.
+     * </p>
+     *
+     * @return A list of Greengrass cores that belong to this Greengrass group.
+     */
+    public List<CoreConnectivityInfo> getCores() {
+        return cores;
+    }
+
+    /**
+     * <p>
+     * A list of Greengrass cores that belong to this Greengrass group.
+     * </p>
+     *
+     * @param cores
+     *            A list of Greengrass cores.
+     */
+    public void setCores(List<CoreConnectivityInfo> cores) {
+        this.cores = cores;
+    }
+
+    /**
+     * <p>
+     * A list of Greengrass cores that belong to this Greengrass group.
+     * </p>
+     *
+     * @param cores
+     *            A list of Greengrass cores.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public GroupConnectivityInfo withCores(List<CoreConnectivityInfo> cores) {
+        this.cores = cores;
+        return this;
+    }
+
+    /**
+     * <p>
+     * A list of Greengrass cores that belong to this Greengrass group.
+     * </p>
+     *
+     * @param cores
+     *            A list of Greengrass cores.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public GroupConnectivityInfo withCores(CoreConnectivityInfo ... cores) {
+        this.cores = Arrays.asList(cores);
+        return this;
+    }
+
+    /**
+     * <p>
+     * A list of CA content strings for this Greengrass group.
+     * </p>
+     *
+     * @return A list of CA content strings.
+     */
+    public List<String> getCas() {
+        return cas;
+    }
+
+    /**
+     * <p>
+     * A list of CA content strings for this Greengrass group.
+     * </p>
+     *
+     * @param cas
+     *            A list of CA content strings.
+     */
+    public void setCas(List<String> cas) {
+        this.cas = cas;
+    }
+
+    /**
+     * <p>
+     * A list of CA content strings for this Greengrass group.
+     * </p>
+     *
+     * @param cas
+     *            A list of CA content strings.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public GroupConnectivityInfo withCas(List<String> cas) {
+        this.cas = cas;
+        return this;
+    }
+
+    /**
+     * <p>
+     * A list of CA content strings for this Greengrass group.
+     * </p>
+     *
+     * @param cas
+     *            A list of CA content strings.
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+    public GroupConnectivityInfo withCas(String ... cas) {
+        this.cas = Arrays.asList(cas);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ggGroupId, cores, cas);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GroupConnectivityInfo that = (GroupConnectivityInfo) o;
+        return Objects.equals(ggGroupId, that.ggGroupId) &&
+            Objects.equals(cores, that.cores) &&
+            Objects.equals(cas, that.cas);
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     *
+     * @return A string representation of this object.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getGgGroupId() != null)
+            sb.append("GGGroupId: ").append(getGgGroupId()).append(',');
+        if (getCores() != null)
+            sb.append("Cores: ").append(getCores()).append(',');
+        if (getCas() != null)
+            sb.append("CAs: ").append(getCas());
+        sb.append("}");
+        return sb.toString();
+    }
+
+}


### PR DESCRIPTION
Adds functionality that allows devices to discover the Greengrass Core device and interacts with Greengrass Core directly (locally).

* Added feature to allow alternate CA to be specified for MQTT connection
author: @timmattison
* Implemented Greengrass discovery feature
* Added BasicDiscovery example
* Update readme