### PR TITLE
Empty version bump to allow for reimport

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ of your Maven project.
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-iot-device-sdk-java</artifactId>
-    <version>1.3.8</version>
+    <version>1.3.9</version>
   </dependency>
 </dependencies>
 ```
@@ -94,7 +94,7 @@ The sample applications included with the SDK can also be installed using the fo
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-iot-device-sdk-java-samples</artifactId>
-    <version>1.3.8</version>
+    <version>1.3.9</version>
   </dependency>
 </dependencies>
 ```

--- a/aws-iot-device-sdk-java-samples/pom.xml
+++ b/aws-iot-device-sdk-java-samples/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-iot-device-sdk-java-pom</artifactId>
-    <version>1.3.8</version>
+    <version>1.3.9</version>
   </parent>
   <artifactId>aws-iot-device-sdk-java-samples</artifactId>
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-iot-device-sdk-java</artifactId>
-      <version>1.3.8</version>
+      <version>1.3.9</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/aws-iot-device-sdk-java-samples/samples-pom.xml
+++ b/aws-iot-device-sdk-java-samples/samples-pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-iot-device-sdk-java-samples</artifactId>
-  <version>1.3.8</version>
+  <version>1.3.9</version>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-iot-device-sdk-java</artifactId>
-      <version>1.3.8</version>
+      <version>1.3.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/aws-iot-device-sdk-java/pom.xml
+++ b/aws-iot-device-sdk-java/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-iot-device-sdk-java-pom</artifactId>
-    <version>1.3.8</version>
+    <version>1.3.9</version>
   </parent>
   <artifactId>aws-iot-device-sdk-java</artifactId>
   <dependencies>

--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/mqtt/AwsIotMqttConnection.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/mqtt/AwsIotMqttConnection.java
@@ -44,7 +44,7 @@ import lombok.Setter;
 @Setter
 public class AwsIotMqttConnection extends AwsIotConnection {
 
-    private static final String USERNAME_METRIC_STRING = "?SDK=Java&Version=1.3.8";
+    private static final String USERNAME_METRIC_STRING = "?SDK=Java&Version=1.3.9";
     private final SocketFactory socketFactory;
 
     private MqttAsyncClient mqttClient;

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-iot-device-sdk-java-pom</artifactId>
-  <version>1.3.8</version>
+  <version>1.3.9</version>
   <packaging>pom</packaging>
   <name>AWS IoT Device SDK for Java</name>
   <description>The AWS IoT Device SDK for Java provides Java APIs for devices to connect to AWS IoT service using the MQTT protocol. The SDK also provides support for AWS IoT specific features, such as Thing Shadow and Thing Shadow abstraction.</description>


### PR DESCRIPTION
Assuming all goes well, 1.3.9 is the version we'll push to maven central shortly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
