### PR TITLE
Changed "Depricated" tag to "depricated"

### DIFF
--- a/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/util/AwsIotWebSocketUrlSigner.java
+++ b/aws-iot-device-sdk-java/src/main/java/com/amazonaws/services/iot/client/util/AwsIotWebSocketUrlSigner.java
@@ -80,7 +80,7 @@ public class AwsIotWebSocketUrlSigner {
      * @param endpoint
      *            service endpoint with or without customer specific URL prefix.
      *
-     * @Deprecated use provider-based constructor
+     * @deprecated use provider-based constructor
      */
     public AwsIotWebSocketUrlSigner(String endpoint) {
         this(endpoint, REGION_TO_BE_DETERMINED);


### PR DESCRIPTION
Ran into "error: unknown tag: Deprecated" during onboard IoT device process at build. Change to lowercase should fix the issue.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
